### PR TITLE
Add tokio-uring benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,7 +582,8 @@ dependencies = [
 
 [[package]]
 name = "monoio"
-version = "0.0.3"
+version = "0.0.4"
+source = "git+https://github.com/bytedance/monoio#a3eaf61ba0b0cf5b44fc5e420ea816cda19df736"
 dependencies = [
  "bytes",
  "futures",
@@ -593,7 +594,6 @@ dependencies = [
  "nix 0.23.0",
  "os_socketaddr",
  "pin-project-lite",
- "pin-utils",
  "scoped-tls",
  "socket2 0.4.2",
 ]
@@ -601,6 +601,7 @@ dependencies = [
 [[package]]
 name = "monoio-macros"
 version = "0.0.2"
+source = "git+https://github.com/bytedance/monoio#a3eaf61ba0b0cf5b44fc5e420ea816cda19df736"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,9 +480,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.108"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "local-sync"
@@ -595,7 +595,7 @@ dependencies = [
  "os_socketaddr",
  "pin-project-lite",
  "scoped-tls",
- "socket2 0.4.2",
+ "socket2 0.4.4",
 ]
 
 [[package]]
@@ -841,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -921,6 +921,28 @@ version = "0.1.0"
 dependencies = [
  "config",
  "tokio",
+]
+
+[[package]]
+name = "tokio-uring"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3ad494f39874984d990ade7f6319dafbcd3301ff0b1841f8a55a1ebb3e742c8"
+dependencies = [
+ "io-uring",
+ "libc",
+ "scoped-tls",
+ "slab",
+ "socket2 0.4.4",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-uring-server"
+version = "0.1.0"
+dependencies = [
+ "config",
+ "tokio-uring",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "monoio-server",
     "tokio-server",
+    "tokio-uring-server",
     "glommio-server",
 
     "client",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 config = {path="../config"}
 
-monoio = {path="../../monoio/monoio"}
+monoio = {git="https://github.com/bytedance/monoio"}
 local-sync = "0.0.5"

--- a/monoio-server/Cargo.toml
+++ b/monoio-server/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 config = {path="../config"}
 
-monoio = {path="../../monoio/monoio"}
+monoio = {git="https://github.com/bytedance/monoio"}

--- a/tokio-uring-server/Cargo.toml
+++ b/tokio-uring-server/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "tokio-uring-server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+config = {path="../config"}
+
+tokio-uring = {version = "0.3"}

--- a/tokio-uring-server/src/main.rs
+++ b/tokio-uring-server/src/main.rs
@@ -1,0 +1,51 @@
+use config::{ServerConfig, PACKET_SIZE};
+
+fn main() {
+    let cfg = ServerConfig::parse();
+    println!(
+        "Running ping pong server with Tokio.\nPacket size: {}\nListen {}",
+        PACKET_SIZE, cfg.bind
+    );
+
+    tokio_uring::start(async {
+        serve(&cfg).await;
+    });
+}
+
+fn successful(result: Result<usize, std::io::Error>) -> bool {
+    if let Ok(size) = result {
+        return size == PACKET_SIZE;
+    }
+
+    false
+}
+
+async fn serve(cfg: &ServerConfig) {
+    let listener = tokio_uring::net::TcpListener::bind(cfg.bind.parse().unwrap()).unwrap();
+
+    loop {
+        let (stream, _) = listener.accept().await.unwrap();
+
+        tokio_uring::spawn(async move {
+            let mut buf = vec![0; PACKET_SIZE];
+
+            loop {
+                let (result, buf2) = stream.read(buf).await;
+
+                if !successful(result) {
+                    return;
+                }
+
+                buf = buf2;
+
+                let (result, buf2) = stream.write(buf).await;
+
+                if !successful(result) {
+                    return;
+                }
+
+                buf = buf2;
+            }
+        });
+    }
+}


### PR DESCRIPTION
This adds a sample server using the tokio-uring 0.3 TCP streams. Note that tokio-uring only supports a single-threaded run-time, so …