### PR TITLE
fix compilation error caused by monoio version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.dependencies]
-monoio = { version = "0.0" }
+monoio = { git = "https://github.com/bytedance/monoio" }
 
 [profile.release]
 lto = true


### PR DESCRIPTION
fix this issue #4 
And it can better adapt to the iterations of the monoio versions